### PR TITLE
Fix invalid ObjectID handling in follows

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -56,7 +56,7 @@ exports.sharedProfileData = async function (req, res, next) {
     const viewer = jwt.verify(req.body.token, process.env.JWTSECRET)
     viewerId = viewer._id
   } catch (e) {
-    viewerId = 0
+    viewerId = null
   }
   req.isFollowing = await Follow.isVisitorFollowing(req.profileUser._id, viewerId)
 

--- a/models/Follow.js
+++ b/models/Follow.js
@@ -62,6 +62,9 @@ Follow.prototype.delete = function() {
 }
 
 Follow.isVisitorFollowing = async function(followedId, visitorId) {
+  if (!ObjectID.isValid(visitorId)) {
+    return false
+  }
   let followDoc = await followsCollection.findOne({followedId: followedId, authorId: new ObjectID(visitorId)})
   if (followDoc) {
     return true


### PR DESCRIPTION
## Summary
- validate visitorId before creating a Mongo ObjectID in Follow.isVisitorFollowing
- treat unauthenticated users as null IDs when checking follow status

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68803eac0ed48326b0d49b9f076803f6